### PR TITLE
model の validation テストの実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -18,6 +18,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Article < ApplicationRecord
+  validates :title, presence: true
+  validates :body, presence: true
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -19,6 +19,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class ArticleLike < ApplicationRecord
+  validates :article_id, uniqueness: { scope: :user_id } # rubocop:disable Rails/UniqueValidationWithoutIndex
   belongs_to :user
   belongs_to :article
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -20,6 +20,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Comment < ApplicationRecord
+  validates :body, presence: true
   belongs_to :user
   belongs_to :article
 end

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -20,7 +20,7 @@
 #
 FactoryBot.define do
   factory :article_like do
-    user { nil }
-    article { nil }
+    user
+    article
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -19,8 +19,8 @@
 #
 FactoryBot.define do
   factory :article do
+    user
     title { "MyString" }
     body { "MyText" }
-    user { nil }
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -21,8 +21,8 @@
 #
 FactoryBot.define do
   factory :comment do
+    user
     body { "MyText" }
-    user { nil }
-    article { nil }
+    article
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: users
@@ -30,16 +28,10 @@
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_users_on_uid_and_provider      (uid,provider) UNIQUE
 #
-class User < ApplicationRecord
-  extend Devise::Models
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
-  include DeviseTokenAuth::Concerns::User
-
-  has_many :articles, dependent: :destroy
-  has_many :comments, dependent: :destroy
-  has_many :article_likes, dependent: :destroy
-  validates :name, presence: true
+FactoryBot.define do
+  factory :user do
+    name { Faker::Name.name }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
+    password { Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true, special_characters: true) }
+  end
 end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -21,5 +21,22 @@
 require "rails_helper"
 
 RSpec.describe ArticleLike, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "いいねしていない記事にいいねをする時" do
+    let(:article_like) { build(:article_like) }
+    it "記事にいいねできる" do
+      expect(article_like).to be_valid
+    end
+  end
+
+  context "すでにいいねをしている記事にいいねをするとき" do
+    before { create(:article_like, user: user, article: article) }
+
+    let(:article_like) { build(:article_like, user: user, article: article) }
+    let(:user) { create(:user) }
+    let(:article) { create(:article) }
+
+    it "いいねに失敗する" do
+      expect(article_like).to be_invalid
+    end
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -20,5 +20,24 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "タイトルと本文に文字が入力されているとき" do
+    let(:article) { build(:article) }
+    it "記事が作成される" do
+      expect(article).to be_valid
+    end
+  end
+
+  context "タイトルが空白のとき" do
+    it "記事の作成に失敗する" do
+      article = build(:article, title: nil)
+      expect(article).not_to be_valid
+    end
+  end
+
+  context "本文が空白のとき" do
+    it "記事の作成に失敗する" do
+      article = build(:article, body: nil)
+      expect(article).not_to be_valid
+    end
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -19,26 +19,25 @@
 #
 require "rails_helper"
 
-# RSpec.describe Article, type: :model do
-#   context "タイトルと本文に文字が入力されているとき" do
-#     binding.pry
-#     let(:article) { build(:article) }
-#     it "記事が作成される" do
-#       expect(article).to be_valid
-#     end
-#   end
+RSpec.describe Article, type: :model do
+  context "タイトルと本文に文字が入力されているとき" do
+    let(:article) { build(:article) }
+    it "記事が作成される" do
+      expect(article).to be_valid
+    end
+  end
 
-#   context "タイトルが空白のとき" do
-#     it "記事の作成に失敗する" do
-#       article = build(:article, title: nil)
-#       expect(article).not_to be_valid
-#     end
-#   end
+  context "タイトルが空白のとき" do
+    it "記事の作成に失敗する" do
+      article = build(:article, title: nil)
+      expect(article).not_to be_valid
+    end
+  end
 
-#   context "本文が空白のとき" do
-#     it "記事の作成に失敗する" do
-#       article = build(:article, body: nil)
-#       expect(article).not_to be_valid
-#     end
-#   end
-# end
+  context "本文が空白のとき" do
+    it "記事の作成に失敗する" do
+      article = build(:article, body: nil)
+      expect(article).not_to be_valid
+    end
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -19,25 +19,26 @@
 #
 require "rails_helper"
 
-RSpec.describe Article, type: :model do
-  context "タイトルと本文に文字が入力されているとき" do
-    let(:article) { build(:article) }
-    it "記事が作成される" do
-      expect(article).to be_valid
-    end
-  end
+# RSpec.describe Article, type: :model do
+#   context "タイトルと本文に文字が入力されているとき" do
+#     binding.pry
+#     let(:article) { build(:article) }
+#     it "記事が作成される" do
+#       expect(article).to be_valid
+#     end
+#   end
 
-  context "タイトルが空白のとき" do
-    it "記事の作成に失敗する" do
-      article = build(:article, title: nil)
-      expect(article).not_to be_valid
-    end
-  end
+#   context "タイトルが空白のとき" do
+#     it "記事の作成に失敗する" do
+#       article = build(:article, title: nil)
+#       expect(article).not_to be_valid
+#     end
+#   end
 
-  context "本文が空白のとき" do
-    it "記事の作成に失敗する" do
-      article = build(:article, body: nil)
-      expect(article).not_to be_valid
-    end
-  end
-end
+#   context "本文が空白のとき" do
+#     it "記事の作成に失敗する" do
+#       article = build(:article, body: nil)
+#       expect(article).not_to be_valid
+#     end
+#   end
+# end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -22,5 +22,17 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "コメントに文字が入力されているとき" do
+    let(:comment) { build(:comment) }
+    it "コメントが作成される" do
+      expect(comment).to be_valid
+    end
+  end
+
+  context "コメントが空白のとき" do
+    it "コメントの作成に失敗する" do
+      comment = build(:comment, body: nil)
+      expect(comment).not_to be_valid
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: users
@@ -30,16 +28,34 @@
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_users_on_uid_and_provider      (uid,provider) UNIQUE
 #
-class User < ApplicationRecord
-  extend Devise::Models
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
-  include DeviseTokenAuth::Concerns::User
+require "rails_helper"
 
-  has_many :articles, dependent: :destroy
-  has_many :comments, dependent: :destroy
-  has_many :article_likes, dependent: :destroy
-  validates :name, presence: true
+RSpec.describe User, type: :model do
+  context "必要な情報が揃っている場合" do
+    let(:user) { build(:user) }
+    it "ユーザー登録できる" do
+      expect(user).to be_valid
+    end
+  end
+
+  context "名前のみ入力している場合" do
+    let(:user) { build(:user, email: nil, password: nil) }
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "emailがない場合" do
+    let(:user) { build(:user, email: nil) }
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "passwordがない場合" do
+    let(:user) { build(:user, password: nil) }
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,4 +89,9 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  # テスト失敗時に最後までテストを走らせる設定を記述
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,6 +92,6 @@ RSpec.configure do |config|
 
   # テスト失敗時に最後までテストを走らせる設定を記述
   config.define_derived_metadata do |meta|
-    meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
+    meta[:aggregate_failures] = true unless meta.has_key?(:aggregate_failures)
   end
 end


### PR DESCRIPTION
## 概要
- 各モデルに必要なバリデーションの設定とテストを実装
## 詳細
- article モデルのバリデーションを追加してテストを実装
  -  記事のタイトルと本文の空白を制限
  
- user モデルにバリデーション追加してテストを簡単に実装
  - email, password に関するバリデーションは devise_token_auth のデフォルトを使用
  
- comment モデルのバリデーションを追加してテストを実装
  - コメントの空白を制限
  
 - article_like モデルのバリデーションを追加してテストを実装
   - 同じ記事に複数回いいねできないように制限（いいねの制限）
 
- テストが失敗した際に、最後までテストを走らせる設定を記述

- 各ファイルの記述修正
  -  article spec,spec_helper