### PR TITLE
endpointを /api/v1 から始まるようにルーティングを設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth"
+      resources :articles
+
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth"
       resources :articles
-
     end
   end
 end


### PR DESCRIPTION
## 概要
- APIのエンドポイントを/api/v1から始まるように設定
## 参考記事
- api/v1をエンドポイントにしたルーティング
  - https://qiita.com/Hashimoto-Noriaki/items/78bc8191b8d6fb159ca8
- Railsのルーティングを学ぼう③
  - https://diveintocode.jp/blogs/Technology/Routing3