### PR TITLE
記事一覧の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,8 @@
+module Api::V1
+  class ArticlesController < BaseApiController
+    def index
+      articles = Article.all
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -20,7 +20,7 @@
 FactoryBot.define do
   factory :article do
     user
-    title { "MyString" }
-    body { "MyText" }
+    title { Faker::Lorem.word }
+    body { Faker::Lorem.sentences }
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -21,6 +21,6 @@ FactoryBot.define do
   factory :article do
     user
     title { Faker::Lorem.word }
-    body { Faker::Lorem.sentences }
+    body { Faker::Lorem.sentence }
   end
 end

--- a/spec/requests/api/v1/article_spec.rb
+++ b/spec/requests/api/v1/article_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Article", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
+
+    before { create_list(:article, 3) }
+
+    it "記事の一覧が取得できる" do # rubocop:disable  RSpec/MultipleExpectations:
+      subject
+
+      res = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- 記事の一覧取得に関する機能とテストを実装
## 詳細
- 記事に関する FactoryBot を実装
- serializer を作成
- 記事の一覧取得機能とテストを実装
- FactoryBotの記述を修正
## 参考記事
- Fakerでダミーデータを生成する
  -  https://qiita.com/Keisuke69/items/edcaadc100361cf945e2
- selializerを使ったAPIの作成と、リクエストスペックについて
  -  https://ryota21silva.hatenablog.com/entry/2020/06/28/195635
- 【RailsAPI】active_model_serializersの基礎からまとめてみた（実践編もあるよ）
  - https://qiita.com/onikan/items/d24ce08adf144c326812 