### PR TITLE
記事一覧機能のテスト関係を修正

### DIFF
--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -20,7 +20,7 @@ RSpec/EmptyLineAfterFinalLet:
 # feature spec は exclude でも良いかもしれない。
 # ヒアドキュメント使うと一瞬で超えるので disable も検討。
 RSpec/ExampleLength:
-  Max: 8
+  Max: 15
 
 # block の方がテスト対象が
 # * `{}` の前後のスペースと相まって目立つ
@@ -42,6 +42,10 @@ RSpec/InstanceVariable:
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。
 RSpec/NamedSubject:
   Enabled: false
+
+# expectの行数の緩和を設定
+RSpec/MultipleExpectations:
+  Max: 10
 
 # Model
 #  `- #method

--- a/spec/requests/api/v1/article_spec.rb
+++ b/spec/requests/api/v1/article_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::Article", type: :request do
+RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
     before { create_list(:article, 3) }
 
-    it "記事の一覧が取得できる" do # rubocop:disable  RSpec/MultipleExpectations:
+    it "記事の一覧が取得できる" do
       subject
 
       res = JSON.parse(response.body)


### PR DESCRIPTION
## 概要
- 記事一覧機能のテスト関連を修正
## 詳細
- 記事一覧機能のテストを修正
  - タイポとrubocopの設定を緩和する記述を削除
- rubocop の設定を緩和