### PR TITLE
Fix:article_preview_serializerを再作成

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,7 +2,7 @@ module Api::V1
   class ArticlesController < BaseApiController
     def index
       articles = Article.all
-      render json: articles, each_serializer: Api::V1::ArticleSerializer
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,28 +1,28 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
-  # describe "GET /articles" do
-  #   subject { get(api_v1_articles_path) }
+  describe "GET api/v1/articles" do
+    subject { get(api_v1_articles_path) }
 
-  #   context "3つの記事を作成するとき" do
-  #     let!(:article1) { create(:article, updated_at: 1.days.ago) }
-  #     let!(:article2) { create(:article, updated_at: 2.days.ago) }
-  #     let!(:article3) { create(:article) }
+    context "3つの記事を作成するとき" do
+      let!(:article1) { create(:article, updated_at: 1.days.ago) }
+      let!(:article2) { create(:article, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article) }
 
-  #     it "記事の一覧が取得できる" do
-  #       subject
-  #       res = JSON.parse(response.body)
+      it "記事の一覧が取得できる" do
+        subject
+        res = JSON.parse(response.body)
 
-  #       expect(response).to have_http_status(:ok)
-  #       expect(res.length).to eq 3
-  #       expect(res.map {|d| d["id"] }).to eq [article1.id, article2.id, article3.id]
-  #       expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
-  #       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
-  #     end
-  #   end
-  # end
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article1.id, article2.id, article3.id]
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+  end
 
-  describe "GET /articles/:id" do
+  describe "GET api/v1/articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
     context "指定した id の記事が存在する場合" do
@@ -52,7 +52,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
   end
 
-  describe "POST /articles/" do
+  describe "POST api/v1/articles/" do
     subject { post(api_v1_articles_path, params: params) }
 
     context "ログインユーザーが適切なパラメーターを送信したとき" do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
-  describe "GET api/v1/articles" do
+  describe "GET articles" do
     subject { get(api_v1_articles_path) }
 
     context "3つの記事を作成するとき" do
@@ -22,7 +22,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
   end
 
-  describe "GET api/v1/articles/:id" do
+  describe "GET articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
     context "指定した id の記事が存在する場合" do
@@ -52,7 +52,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
   end
 
-  describe "POST api/v1/articles/" do
+  describe "POST articles/" do
     subject { post(api_v1_articles_path, params: params) }
 
     context "ログインユーザーが適切なパラメーターを送信したとき" do


### PR DESCRIPTION
## 概要
- 削除した`article_preview_serializer.rb`のファイルとしての役割を理解し再度生成。

## 詳細
- describe句のルーティングを修正
-  describe句を再確認し、再度修正