### PR TITLE
記事削除の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -21,6 +21,11 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
+    def destroy
+      article = current_user.articles.find(params[:id])
+      article.destroy!
+    end
+
     private
 
       def article_params

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -94,11 +94,39 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
 
-    context "自分以外の人が作成している記事のレコードを更新をするとき" do
+    context "他人が作成している記事のレコードを更新をするとき" do
       let(:other_user) { create(:user) }
       let!(:article) { create(:article, user: other_user) }
       it "更新できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe "DELETE /articles/:id" do
+    subject { delete(api_v1_article_path(article_id)) }
+
+    # devise_token_auth の導入が完了後に削除
+    let(:current_user) { create(:user) }
+    let(:article_id) { article.id }
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) } # rubocop:disable all
+
+    context "自分の記事を削除しようとするとき" do
+      let!(:article) { create(:article, user: current_user) }
+
+      it "記事を削除できる" do
+        expect { subject }.to change { Article.count }.by(-1)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "他人が作成した記事のレコードを削除しようとするとき" do
+      let(:other_user) { create(:user) }
+      let!(:article) { create(:article, user: other_user) }
+
+      it "記事を削除できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound) &
+                              change { Article.count }.by(0)
       end
     end
   end


### PR DESCRIPTION
## 概要
- 記事削除のAPIおよびテストの実装
## 詳細
- `api/v1/articles_controller.rb`に`destroy`メソッドを定義

- `requests/api/v1/articles_spec.rb`に`destroy`メソッドのテストを実装
  - 正常系:自分の記事を削除しようとするとき、記事を削除できる。
  - 異常系:他人が作成した記事のレコードを削除しようとするとき、記事を削除できない