### PR TITLE
新規登録 API の実装

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  private
+
+    def sign_up_params
+      params.permit(:name, :email, :password, :password_confirmation)
+    end
+
+    def account_update_params
+      params.permit(:name, :email)
+    end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,7 @@ module WonderfulEditor
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
-  # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  # determines howlong tokens willremain valid after they are issued.
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +42,12 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                           'client': "client",
+                           'expiry': "expiry",
+                           'uid': "uid",
+                           'token-type': "token-type",
+                           'authorization': "authorization" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   root to: "home#index"
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: "api/v1/auth/registrations",
+      }
       resources :articles
     end
   end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要
- `devise_token_auth`を用いた新規登録の実装
## 詳細
- 認証用の `controller `を作成
  - `devise_token_authgem`で用意されている認証用のコントローラーを`registrations_controller`に継承
- 認証用の `path` を記述
  - `api/v1/auth`のpathと対応するcontrollerがリクエストが通る様に`routes.rb`に記述
- `CSRF対策`をOFFにする様に記述
- エラー対策の記述を行う
- 認証時レスポンスとして返す `header` 情報を設定
- `rails`コマンドにて実行時にテストファイルを作成

## 動作確認
- `tableplus`にて`user`を作成されていることが確認
<img width="1440" alt="スクリーンショット 2023-03-13 22 38 03" src="https://user-images.githubusercontent.com/100144368/224722991-82d5db6d-e54e-4a01-9d1d-34b72f0ba0e9.png">

- `postman`でリクエストが返ってきていることを確認
<img width="1440" alt="スクリーンショット 2023-03-13 22 37 41" src="https://user-images.githubusercontent.com/100144368/224723825-4e688da4-6f83-437a-9672-f8b957843464.png">


## 参考記事

- 【Rails API 入門】devise-token-auth
  - https://qiita.com/tomokazu0112/items/5fdd6a51a84c520c45b5

- devise_token_authの使い方
  - https://qiita.com/Hashimoto-Noriaki/items/4dbad98f2dcc009fa609
- 公式ドキュメント devise_token_auth
  - https://devise-token-auth.gitbook.io/devise-token-auth/config
- Rails5 + APIモードで後からdeviseを使おうとした時のエラー対応
  - https://qiita.com/Philomagi/items/4fc83d49a6065002273e
- Unpermitted parameter: :registration #1178
  - https://github.com/lynndylanhurley/devise_token_auth/issues/1540