### PR TITLE
新規登録 API のテストの実装

### DIFF
--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,7 +1,61 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "POST /v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+
+    context "必要な情報が存在するとき" do
+      let(:params) { attributes_for(:user) }
+
+      it "ユーザーの新規登録が出来る" do
+        expect { subject }.to change { User.count }.by(1)
+        expect(response).to have_http_status(:ok)
+        res = JSON.parse(response.body)
+        expect(res["data"]["email"]).to eq(User.last.email)
+      end
+
+      it "header 情報を取得することができる" do
+        subject
+        header = response.header
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["expiry"]).to be_present
+        expect(header["uid"]).to be_present
+        expect(header["token-type"]).to be_present
+      end
+    end
+
+    context "name が存在しないとき" do
+      let(:params) { attributes_for(:user, name: nil) }
+
+      it "エラーする" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(res["errors"]["name"]).to include "can't be blank"
+      end
+    end
+
+    context "email が存在しないとき" do
+      let(:params) { attributes_for(:user, email: nil) }
+
+      it "エラーする" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(res["errors"]["email"]).to include "can't be blank"
+      end
+    end
+
+    context "password が存在しないとき" do
+      let(:params) { attributes_for(:user, password: nil) }
+
+      it "エラーする" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(res["errors"]["password"]).to include "can't be blank"
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
- 新規登録のテストのAPIの実装
## 詳細
- テストのパターンを洗い出し
  - 正常系:必要な情報が存在するとき、ユーザーの新規登録ができる。
  - 正常系:header 情報を取得することができる
  - 異常系:name,email,passwordが存在しない時、エラーする
- エラーのステータスを取得し、記述。

