### PR TITLE
ログインAPIの実装

### DIFF
--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Sessions", type: :request do
+  describe "POST /api/v1/auth/sign_in" do
+    subject { post(api_v1_user_session_path, params: params) }
+
+    context "登録済のユーザー情報を送信したとき" do
+      let(:user) { create(:user) }
+      let(:params) { attributes_for(:user, email: user.email, password: user.password) }
+
+      it "ログインできる" do
+        subject
+        header = response.header
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(headers["uid"]).to be_present
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "emailが一致しないとき" do
+      let(:user) { create(:user) }
+      let(:params) { attributes_for(:user, email: "hoge", password: user.password) }
+
+      it "ログインできない" do
+        subject
+        res = JSON.parse(response.body)
+        header = response.header
+        expect(res["errors"]).to include "Invalid login credentials. Please try again."
+        expect(header["access-token"]).to be_blank
+        expect(header["client"]).to be_blank
+        expect(headers["uid"]).to be_blank
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "passwordが一致しない場合" do
+      let(:user) { create(:user) }
+      let(:params) { attributes_for(:user, email: user.email, password: "hoge") }
+
+      it "ログインできない" do
+        subject
+        res = JSON.parse(response.body)
+        header = response.header
+        expect(res["errors"]).to include "Invalid login credentials. Please try again."
+        expect(header["access-token"]).to be_blank
+        expect(header["client"]).to be_blank
+        expect(headers["uid"]).to be_blank
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- `devise_token_auth` を使用したログインのテストの実装

## 詳細
- テストパターンの洗い出し
  - 正常系:登録済のユーザー情報を送信したとき、ログインできる
  - 異常系:`email`が一致しないとき、ログインできない
  - 異常系:`password`が一致しないとき、ログインできない

## 動作確認
<img width="1440" alt="スクリーンショット 2023-03-17 22 11 50" src="https://user-images.githubusercontent.com/100144368/225914467-46eba333-4cfe-4292-87ea-cb9973cd7d16.png">

<img width="1440" alt="スクリーンショット 2023-03-17 22 15 00" src="https://user-images.githubusercontent.com/100144368/225915438-235834b0-614d-493b-b777-b375454e46c7.png">

## 参考記事
- postmanによるdevise_token_authのログイン
   - https://qiita.com/kanon_ayuayu/items/9f4e361a00a32a377581