### PR TITLE
ログアウトAPIのテストを実装

### DIFF
--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -50,4 +50,30 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
       end
     end
   end
+
+  describe "DELETE /api/v1/auth/sign_out" do
+    subject { delete(destroy_api_v1_user_session_path, headers: headers) }
+
+    context "ログアウトに必要な情報を送信したとき" do
+      let(:user) { create(:user) }
+      let!(:headers) { user.create_new_auth_token }
+
+      it "ログアウトできる" do
+        expect { subject }.to change { user.reload.tokens }.from(be_present).to(be_blank)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "誤った情報を送信したとき" do
+      let(:user) { create(:user) }
+      let!(:headers) { { "access-token" => "", "token-type" => "", "client" => "", "expiry" => "", "uid" => "" } }
+
+      it "ログアウトできない" do
+        subject
+        expect(response).to have_http_status(:not_found)
+        res = JSON.parse(response.body)
+        expect(res["errors"]).to include "User was not found or was not logged in."
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- `devise_token_auth` を使用したログアウトのテストの実装

## 詳細
- テストパターンの洗い出し
  - 正常系:ログアウトに必要な情報を送信したとき、ログアウトできる
  - 異常系:誤った情報を送信したとき、ログアウトできない

## 動作確認
<img width="1440" alt="スクリーンショット 2023-03-20 7 35 24" src="https://user-images.githubusercontent.com/100144368/226214573-289ec233-198f-443c-9309-1100f32b5c29.png">

<img width="1440" alt="スクリーンショット 2023-03-20 7 38 13" src="https://user-images.githubusercontent.com/100144368/226214656-3d8b9500-e607-4763-a826-622146fd06c2.png">

