### PR TITLE
Article model に下書き機能を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -23,4 +24,5 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+  enum status: { draft: "draft", published: "published" }
 end

--- a/db/migrate/20230517150714_add_status_to_articles.rb
+++ b/db/migrate/20230517150714_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :string, default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_18_153039) do
+ActiveRecord::Schema.define(version: 2023_05_17_150714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2022_08_18_153039) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
@@ -56,7 +57,6 @@ ActiveRecord::Schema.define(version: 2022_08_18_153039) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.string "name"
-    t.string "nickname"
     t.string "image"
     t.string "email"
     t.json "tokens"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -22,5 +23,13 @@ FactoryBot.define do
     user
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
+  end
+
+  trait :draft do
+    status { :draft }
+  end
+
+  trait :published do
+    status { :published }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -38,6 +39,33 @@ RSpec.describe Article, type: :model do
     it "記事の作成に失敗する" do
       article = build(:article, body: nil)
       expect(article).not_to be_valid
+    end
+  end
+
+  describe "正常に記事が作成されている時" do
+    context "タイトルと本文が入力されているとき" do
+      let(:article) { build(:article) }
+
+      it "下書き状態の記事が作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "status が下書き状態のとき" do
+      let(:article) { build(:article, status: "draft") }
+      it "記事を下書き状態で作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "status が公開状態のとき" do
+      let(:article) { build(:article, status: "published") }
+      it "記事を公開状態で作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
     end
   end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "DELETE /articles/:id" do
     subject { delete(api_v1_article_path(article_id), headers: headers) }
 
-
     let(:current_user) { create(:user) }
     let(:article_id) { article.id }
     let(:headers) { current_user.create_new_auth_token }

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "DELETE /articles/:id" do
     subject { delete(api_v1_article_path(article_id), headers: headers) }
 
-    # devise_token_auth の導入が完了後に削除
+
     let(:current_user) { create(:user) }
     let(:article_id) { article.id }
     let(:headers) { current_user.create_new_auth_token }


### PR DESCRIPTION
## 概要
- 記事の model に enum を使って下書き状態と公開状態を実装
-  Article model のテストを実装

## 詳細
- `article model`にenumを設定
- `status`カラムを追加したマイグレーションファイルを作成
- `model`のテストを実装
    - 下書き記事として保存できる
    - 公開状態で記事を保存できる

- 不要なコメントアウトを削除


## 参考記事
- Ruby on Railsでテーブルのカラムを追加・削除する方法
    - https://reasonable-code.com/rails-column/
  
- RSpec FactoryBotのtaritでテストデータを簡潔に作成
  - https://zenn.dev/konch/articles/8a15758e1bd96a
- 【Rails】Enumってどんな子？使えるの？
  - https://qiita.com/ozackiee/items/17b91e26fad58e147f2e
 - 【Rails入門】enumの使い方まとめ
   - https://www.sejuku.net/blog/26369 
 - Railsのenumを使いこなす方法（翻訳）
   - https://techracho.bpsinc.jp/hachi8833/2022_02_18/115735 