### PR TITLE
既存 API の修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,13 +1,14 @@
 module Api::V1
   class ArticlesController < BaseApiController
     before_action :authenticate_user!, only: [:create, :update, :destroy]
+
     def index
-      articles = Article.all
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      article = Article.find(params[:id])
+      article = Article.published.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
@@ -30,7 +31,7 @@ module Api::V1
     private
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :status, :body, :updated_at
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -4,42 +4,55 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET articles" do
     subject { get(api_v1_articles_path) }
 
-    context "3つの記事を作成するとき" do
-      let!(:article1) { create(:article, updated_at: 1.days.ago) }
-      let!(:article2) { create(:article, updated_at: 2.days.ago) }
-      let!(:article3) { create(:article) }
+    context "3つの公開済みの記事を作成するとき" do
+      let!(:article1) { create(:article, :published, updated_at: 1.days.ago) }
+      let!(:article2) { create(:article, :published, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article, :published) }
 
-      it "記事の一覧が取得できる" do
+      before { create(:article, :draft) }
+
+      it "公開済みの記事一覧が取得できる（更新順)" do
         subject
         res = JSON.parse(response.body)
 
         expect(response).to have_http_status(:ok)
         expect(res.length).to eq 3
-        expect(res.map {|d| d["id"] }).to eq [article1.id, article2.id, article3.id]
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
         expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
         expect(res[0]["user"].keys).to eq ["id", "name", "email"]
       end
     end
   end
 
-  describe "GET articles/:id" do
+  describe "GET /articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "指定した id の記事が存在する場合" do
-      let(:article) { create(:article) }
+    context "指定した id の記事が存在してかつ" do
       let(:article_id) { article.id }
 
-      it "任意の記事の値が取得できる" do
-        subject
-        res = JSON.parse(response.body)
+      context "対象の記事が公開中であるとき" do
+        let(:article) { create(:article, :published) }
 
-        expect(response).to have_http_status(:ok)
-        expect(res["id"]).to eq article.id
-        expect(res["title"]).to eq article.title
-        expect(res["body"]).to eq article.body
-        expect(res["updated_at"]).to be_present
-        expect(res["user"]["id"]).to eq article.user.id
-        expect(res["user"].keys).to eq ["id", "name", "email"]
+        it "任意の記事が取得できる" do
+          subject
+          res = JSON.parse(response.body)
+
+          expect(response).to have_http_status(:ok)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "name", "email"]
+        end
+      end
+
+      context "対象の記事が下書き状態であるとき" do
+        let(:article) { create(:article, :draft) }
+
+        it "記事が見つからない" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
       end
     end
 
@@ -52,13 +65,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
   end
 
-  describe "POST articles" do
+  describe "POST /articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
 
-    context "ログインユーザーが適切なパラメーターを送信したとき" do
-      let(:params) { { article: attributes_for(:article) } }
-      let(:current_user) { create(:user) }
-      let(:headers) { current_user.create_new_auth_token }
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "公開指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, :published) } }
 
       it "記事のレコードが作成される" do
         expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
@@ -69,36 +83,51 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
 
-    context "ログインしていないユーザーがパラメーターを送信したとき" do
-      let(:params) { { article: attributes_for(:article) } }
-      it "エラーする" do
-        subject
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
-  end
+    context "下書き指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, :draft) } }
 
-  describe "PATCH（PUT) /articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
-
-    let(:params) { { article: attributes_for(:article) } }
-    let(:current_user) { create(:user) }
-    let(:headers) { current_user.create_new_auth_token }
-
-    context "自分で作成している記事のレコードを更新をするとき" do
-      let(:article) { create(:article, user: current_user) }
-      it "記事を更新できる" do
-        expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
-                              change { article.reload.body }.from(article.body).to(params[:article][:body])
+      it "下書き記事が作成できる" do
+        expect { subject }.to change { Article.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "draft"
         expect(response).to have_http_status(:ok)
       end
     end
 
-    context "他人が作成している記事のレコードを更新をするとき" do
+    context "でたらめな指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, status: :foo) } }
+
+      it "エラーになる" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe "PATCH（PUT) api/v1/articles/:id" do
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
+
+    let(:params) { { article: attributes_for(:article, :published) } }
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "自分の記事を更新をするとき" do
+      let(:article) { create(:article, :draft, user: current_user) }
+
+      it "任意の記事の更新ができる" do
+        expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
+                              change { article.reload.body }.from(article.body).to(params[:article][:body]) &
+                              change { article.reload.status }.from(article.status).to(params[:article][:status].to_s)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "他のユーザーが作成している記事を更新をするとき" do
       let(:other_user) { create(:user) }
       let!(:article) { create(:article, user: other_user) }
+
       it "更新できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        change { Article.count }.by(0)
       end
     end
   end


### PR DESCRIPTION
## 概要
- 既存の記事周りに関する API とそのテスト修正

## 詳細
- 公開記事だけを取得できるように修正
- 記事作成は記事の公開/非公開を選択できるように修正
- serializerに` status`カラムを追加
- 記事のAPIに関するテストを修正

## 参考記事
- 表示順の変更にorderメソッドを使う
  -  https://qiita.com/ryuuuuuuuuuu/items/b537354194cce492cc6f
- [rails]orderメソッドの使い方やパフォーマンスについて
  - https://zenn.dev/kingdom0927/articles/ae9ba7ec878c72
